### PR TITLE
chore: ignore the Playwright MCP artifact directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ coverage
 # (Claude Code writes .claude/settings.local.json and .claude/worktrees/).
 .claude/*
 !.claude/skills
+
+# Page snapshots and console logs the Playwright MCP server drops in the repo
+# root while an agent drives the app.
+.playwright-mcp


### PR DESCRIPTION
The Playwright MCP server writes page snapshots and console logs into `.playwright-mcp/` in the repo root while an agent drives the app. Those were showing up as untracked files, so an unqualified `git add .` would sweep them into a commit — and the `.yml` snapshots were being linted as YAML on every `eslint .` run.

Adds `.playwright-mcp` to `.gitignore`, next to the existing agent-config block. The console logs were already covered by the `*.log*` rule; the snapshots were not.

Verified: `pnpm lint` is clean and the three snapshot files have dropped out of ESLint's file list.