### PR TITLE
docs(agents): correct the @nuxt/icon module claim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,9 +22,12 @@ hosted instance at [fritzdns.piscis.dev/api](https://fritzdns.piscis.dev/api/).
 
 ## Stack
 
-- Nuxt 4 (`app/` srcDir), Vue 3, Nuxt UI v4 (Tailwind CSS v4). Nuxt UI also brings
-  `@nuxt/fonts`, `@nuxtjs/color-mode` and `@nuxt/icon` — do not register those
-  separately. Design tokens live in `app/assets/css/main.css`.
+- Nuxt 4 (`app/` srcDir), Vue 3, Nuxt UI v4 (Tailwind CSS v4). Nuxt UI depends on
+  `@nuxt/fonts`, `@nuxtjs/color-mode` and `@nuxt/icon`, so do not add those to
+  `modules` — with one deliberate exception: `@nuxt/icon` *is* listed, to keep its
+  `icon.clientBundle` config applying to the prerendered landing page. Removing the
+  entry builds and renders identically, so treat it as pinning intent rather than a
+  requirement. Design tokens live in `app/assets/css/main.css`.
 - oRPC 1.x (`@orpc/server`, `@orpc/openapi`, `@orpc/zod`) + Zod 4 on every request
   and response
 - `cloudflare` SDK v7 for zone and DNS access; `consola` logging; `radash` helpers


### PR DESCRIPTION
Found while auditing whether any docs still contradicted the code after the Nuxt UI migration.

## The contradiction

`AGENTS.md` said:

> Nuxt UI also brings `@nuxt/fonts`, `@nuxtjs/color-mode` and `@nuxt/icon` — **do not register those separately**.

But `nuxt.config.ts` *does* register `@nuxt/icon` in `modules`, and it's also a direct dependency. So the instruction contradicted the config it was describing — an agent following it would have "corrected" a working setup.

## What I verified

`@nuxt/ui@4` genuinely does depend on all three (`@nuxt/icon ^2.3.1`, `@nuxt/fonts ^0.14.0`, `@nuxtjs/color-mode ^4.0.1`), so the general advice is right. Only the `@nuxt/icon` part was wrong.

Removing the entry and rebuilding:

- build succeeds
- prerendered `index.html` is **byte-identical** (15305 bytes both)
- same file count (1554)
- only chunk content-hashes shift, which is expected from reordering the module graph

So the registration is **redundant, not load-bearing**.

## Why I fixed the doc rather than the config

The config carries a deliberate comment about keeping `icon.clientBundle` applied to the prerendered landing page, and I'd rather not rewrite chunk hashes on a just-released production build for a cosmetic cleanup. The doc now states the exception and says explicitly that it's pinning intent rather than a requirement — so a future reader knows it can go.

Docs only. Lint, typecheck and 77 tests all pass.

## Separate observation, not changed here

The prerendered page renders the icon as an empty span:

```html
<span class="iconify i-devicon:github inline-block h-5 w-5 mx-2" aria-hidden="true"></span>
```

with the icon data in a client chunk, so it fills in at hydration. The comment in `nuxt.config.ts` says the `clientBundle` config exists specifically to avoid "an empty `<span>`" — but that's what ships. This may be entirely fine (Nuxt UI's `UIcon` is CSS-class based by design, unlike `@nuxt/icon`'s `<Icon>`), so I've left it alone — flagging it in case the comment's rationale no longer matches how `UIcon` renders.