### PR TITLE
chore(deps): declare h3 and drop shamefullyHoist

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@vitest/coverage-v8": "4.1.10",
     "@vue/test-utils": "^2.4.11",
     "eslint": "^10.8.0",
+    "h3": "^1.15.11",
     "happy-dom": "^20.11.1",
     "node-mock-http": "^1.0.5",
     "release-it": "^21.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       eslint:
         specifier: ^10.8.0
         version: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
+      h3:
+        specifier: ^1.15.11
+        version: 1.15.11
       happy-dom:
         specifier: ^20.11.1
         version: 20.11.1
@@ -3989,9 +3992,6 @@ packages:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
 
-  defu@6.1.4:
-    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
-
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
@@ -6871,9 +6871,6 @@ packages:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
-
-  ufo@1.6.3:
-    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
@@ -11852,8 +11849,6 @@ snapshots:
 
   define-lazy-prop@3.0.0: {}
 
-  defu@6.1.4: {}
-
   defu@6.1.7: {}
 
   degenerator@7.0.1(quickjs-wasi@2.2.0):
@@ -12753,7 +12748,7 @@ snapshots:
       iron-webcrypto: 1.2.1
       node-mock-http: 1.0.5
       radix3: 1.1.2
-      ufo: 1.6.3
+      ufo: 1.6.4
       uncrypto: 0.1.3
 
   h3@2.0.1-rc.26(crossws@0.4.10(srvx@0.11.22)):
@@ -13754,7 +13749,7 @@ snapshots:
       acorn: 8.16.0
       pathe: 2.0.3
       pkg-types: 1.3.1
-      ufo: 1.6.3
+      ufo: 1.6.4
 
   mocked-exports@0.1.1: {}
 
@@ -14121,7 +14116,7 @@ snapshots:
     dependencies:
       destr: 2.0.5
       node-fetch-native: 1.6.7
-      ufo: 1.6.3
+      ufo: 1.6.4
 
   ofetch@2.0.0-alpha.3: {}
 
@@ -15357,8 +15352,6 @@ snapshots:
 
   typescript@6.0.3: {}
 
-  ufo@1.6.3: {}
-
   ufo@1.6.4: {}
 
   uglify-js@3.19.3:
@@ -15580,7 +15573,7 @@ snapshots:
   unrouting@0.2.2:
     dependencies:
       escape-string-regexp: 5.0.0
-      ufo: 1.6.3
+      ufo: 1.6.4
 
   unrs-resolver@1.11.1:
     dependencies:
@@ -15625,7 +15618,7 @@ snapshots:
   untyped@2.0.0:
     dependencies:
       citty: 0.1.6
-      defu: 6.1.4
+      defu: 6.1.7
       jiti: 2.6.1
       knitwork: 1.3.0
       scule: 1.3.0
@@ -15929,7 +15922,7 @@ snapshots:
       acorn-import-phases: 1.0.4(acorn@8.18.0)
       browserslist: 4.28.7
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.18.4
+      enhanced-resolve: 5.24.5
       es-module-lexer: 1.7.0
       eslint-scope: 5.1.1
       events: 3.3.0
@@ -15940,7 +15933,7 @@ snapshots:
       mime-types: 2.1.35
       neo-async: 2.6.2
       schema-utils: 4.3.3
-      tapable: 2.3.0
+      tapable: 2.3.3
       terser-webpack-plugin: 5.3.16(esbuild@0.28.1)(uglify-js@3.19.3)(webpack@5.103.0(esbuild@0.28.1)(uglify-js@3.19.3))
       watchpack: 2.5.1
       webpack-sources: 3.5.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,8 @@ minimumReleaseAgeExclude:
   - release-it@21.0.1
   - wrangler@4.118.0
 
-shamefullyHoist: true
+# Required by @antfu/eslint-config, which pins this through
+# `pnpm/yaml-enforce-settings`. Removing it fails `pnpm lint`.
 shellEmulator: true
 trustPolicy: no-downgrade
 

--- a/server/plugins/x-powered-by.ts
+++ b/server/plugins/x-powered-by.ts
@@ -1,7 +1,9 @@
-import type { RenderResponse } from 'nitropack'
-
 export default defineNitroPlugin((nitroApp) => {
-  nitroApp.hooks.hook('render:response', (response: Partial<RenderResponse>) => {
+  // `response` is inferred from Nitro's own `render:response` hook signature.
+  // Annotating it explicitly would mean importing `RenderResponse` from
+  // `nitropack` — a transitive of `nuxt` we would then have to declare, which
+  // re-resolves nitro's own `srvx` and churns the lockfile for no benefit.
+  nitroApp.hooks.hook('render:response', (response) => {
     if (response.headers) {
       delete response.headers['X-Powered-By']
       delete response.headers['x-powered-by']


### PR DESCRIPTION
Removes the last two phantom dependencies and the `shamefullyHoist` flag that was hiding them.

`shamefullyHoist: true` dates to this repo's **initial commit** (as `shamefully-hoist=true` in
`.npmrc`) and was carried into `pnpm-workspace.yaml` mechanically during the pnpm 11 upgrade
(1a91824). Every other key in that file carries a comment explaining itself; this one did not.
With a flat `node_modules`, two packages resolved despite being declared nowhere.

## The two phantoms

An import scan of all 32 source files against `package.json` found exactly two:

| Package | Used in | Kind |
|---|---|---|
| `h3` | `server/router/procedures/*`, `server/router/middlewares/noCacheHeaders.ts` | `import type { H3Event }` |
| | `tests/helpers/h3.ts`, `tests/setup/nitro-globals.ts` | **runtime** `import { createEvent, … }` |
| `nitropack` | `server/plugins/x-powered-by.ts` | `import type { RenderResponse }` |

Both are deep transitives — `nuxt` → `@nuxt/nitro-server` → `nitropack` → `h3` — and neither appears
in `nuxt`'s own `dependencies`. A patch bump moving Nitro to h3 v2 would have broken these with no
signal from `package.json`.

They are fixed differently, on purpose:

- **`h3` is declared** (`devDependencies`, pinned to the resolved `^1.15.11` so pnpm dedupes to the
  instance Nitro already uses). It has genuine runtime use in the test helpers.
- **`nitropack` is not declared — the import is deleted.** Declaring it re-resolved Nitro's own
  `srvx` from 0.11.22 to 0.12.5 and churned 234 lockfile lines; `h3` alone causes zero drift, and a
  pristine `package.json` causes none. Its only use was a type annotation, and Nitro already types
  the `render:response` hook, so the parameter is now inferred. The lockfile diff is 27 lines of
  pure dedupe instead (`ufo` 1.6.3→1.6.4, `defu` 6.1.4→6.1.7, collapsing duplicate copies).

A re-scan after these changes returns **zero** phantom imports.

## `shellEmulator` stays

It was audited alongside `shamefullyHoist` and turns out not to be optional: `@antfu/eslint-config`
9.2.0 pins it through `pnpm/yaml-enforce-settings`, so removing it fails `pnpm lint`. It is restored
**with a comment** recording that — which is the state the file should have been in all along.

Three other declared-but-never-imported packages were checked and deliberately kept, as they are
load-bearing despite no direct import: `@vue/test-utils` (an optional peer of `@nuxt/test-utils` that
`mountSuspended` needs), `@iconify-json/lucide` (`@nuxt/ui` ships `@nuxt/icon` but not the Lucide
set), and the CLI-only tools.

## Verification

Run on a copy **outside** the repository, so nothing could resolve out of a parent `node_modules`:

| Gate | Result |
|---|---|
| `pnpm install` (cold, no prior `node_modules`) | pass |
| `pnpm lint` | pass |
| `pnpm typecheck` (`vue-tsc`) | pass |
| `pnpm test` | pass — 77/77 |
| `pnpm build` (node-server preset) | pass |
| `NITRO_PRESET=cloudflare_module nuxt build` | pass |

`node_modules` is now strict: `vue`, `@vueuse/core`, `ofetch` and `reka-ui` are no longer at the
root, while declared packages are.

## One thing to know before merging

In an **existing** worktree under `.claude/worktrees/`, tests will fail with duplicate-Vue errors
until this lands on `main`. The worktree gets the new strict layout while the parent checkout still
has the old hoisted one, so bare `vue` resolution escapes upward into the parent's `node_modules` and
loads a second copy. It is transitional — once both sides use the strict layout they agree — but a
`pnpm install` in existing checkouts after merging is worth doing.
