### PR TITLE
fix(deploy): let Nitro auto-detect the Vercel preset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ hosted instance at [fritzdns.piscis.dev/api](https://fritzdns.piscis.dev/api/).
 | Command | Purpose |
 |---------|---------|
 | `pnpm dev` | Dev server on `:3000` (via `phase run`) |
-| `pnpm build` | Production build, `node-server` preset |
+| `pnpm build` | Production build (Nitro default / host auto-detect) |
 | `pnpm build:cf` | Cloudflare Workers build (via `phase run`) |
 | `pnpm deploy:cf` | `wrangler deploy` — requires a preceding `build:cf` |
 | `pnpm lint` / `pnpm lint:fix` | ESLint (Antfu + Nuxt flat config) |

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ is never read from the environment and never stored.
 
 | Variable | Consumed by | When | Required |
 | --- | --- | --- | --- |
-| `NITRO_PRESET` | `nuxt.config.ts` → `nitro.preset` | build | Cloudflare/Vercel only |
+| `NITRO_PRESET` | `nuxt.config.ts` → `nitro.preset` | build | Cloudflare only (Vercel auto-detects) |
 | `CF_WORKER_NAME` | `nuxt.config.ts` → `wrangler.name` | build | Cloudflare only |
 | `CF_ROUTE_PATTERN` | `nuxt.config.ts` → `wrangler.route.pattern` | build | Cloudflare only |
 | `CF_LOG_ENABLED` | `nuxt.config.ts` → `wrangler.observability.enabled` | build | no |

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -111,7 +111,12 @@ export default defineNuxtConfig({
     experimental: {
       wasm: true,
     },
-    preset: env('NITRO_PRESET', 'node-server'),
+    // Only pin a preset when NITRO_PRESET is set (e.g. cloudflare_module for
+    // build:cf). Leaving it unset lets Nitro auto-detect — on Vercel that is
+    // the vercel preset, which the Deploy Button one-click flow needs.
+    ...(env('NITRO_PRESET')
+      ? { preset: env('NITRO_PRESET') }
+      : {}),
     cloudflare: {
       deployConfig: true,
       nodeCompat: true,


### PR DESCRIPTION
## Summary
- Only set `nitro.preset` when `NITRO_PRESET` is non-empty, so Vercel one-click auto-detects the `vercel` preset instead of building `node-server` and failing on a missing `dist` directory.
- Cloudflare builds still pin `cloudflare_module` via `build:cf` / CI.
- Docs updated to match auto-detect behaviour.

## Test plan
- [ ] Redeploy via the README Deploy with Vercel button
- [ ] Confirm the build log shows `Nitro preset: vercel` (not `node-server`)
- [ ] Confirm the deploy succeeds past the previous `No Output Directory named "dist"` error
- [ ] Hit `/api/health-check` on the new Vercel URL
- [ ] Confirm CI (lint / typecheck / test) is green on this PR