### PR TITLE
feat(cloudflare): add a one-click Deploy to Cloudflare button

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,11 @@ NITRO_PRESET=cloudflare_module
 
 # Build-time. Consumed by nuxt.config.ts to generate .output/server/wrangler.json,
 # so these must be set for `build:cf`, not just for `deploy:cf`.
+#
+# Both names below are optional. Leave CF_ROUTE_PATTERN empty and no custom-domain
+# route is emitted -- the Worker gets a workers.dev subdomain instead, which is what
+# the one-click "Deploy to Cloudflare" button produces. Leave CF_WORKER_NAME empty
+# and the name falls back to the one in wrangler.jsonc.
 CF_WORKER_NAME=fritzbox-cf-dyndns
 CF_ROUTE_PATTERN=fritzdns.example.com
 CF_LOG_ENABLED=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ hosted instance at [fritzdns.piscis.dev/api](https://fritzdns.piscis.dev/api/).
   and response
 - `cloudflare` SDK v7 for zone and DNS access; `consola` logging; `radash` helpers
 - Cloudflare Workers (`cloudflare_module` preset). Vercel is a secondary,
-  out-of-band target kept alive for the one-click deploy button.
+  out-of-band target. Both have a one-click deploy button in the README.
 - Vitest projects `unit` / `nuxt` / `e2e` (`@nuxt/test-utils`), coverage via
   `@vitest/coverage-v8`
 
@@ -81,6 +81,27 @@ Both use Cloudflare Smart Placement (`placement.mode: 'smart'`) and observabilit
 full head sampling, set in `nuxt.config.ts` and baked into the generated
 `.output/server/wrangler.json` at build time.
 
+**`wrangler.jsonc` in the repo root is not that config.** It exists only so the README's
+Deploy to Cloudflare button recognises the repo as a Workers app and has a `name` to
+rewrite for the person clicking it. `nuxt build` writes `.wrangler/deploy/config.json`
+pointing at the generated `.output/server/wrangler.json`, and wrangler follows that
+redirect in preference to any root config. Nitro additionally merges `wrangler.jsonc`
+*underneath* `nitro.cloudflare.wrangler`, so keys set in both are won by `nuxt.config.ts`,
+and `main`/`assets` are always re-derived (hence two `is overridden and will be ignored`
+warnings per Cloudflare build — expected, not a regression). Edit `nuxt.config.ts` to
+change staging or production; editing `wrangler.jsonc` changes neither.
+
+`CF_WORKER_NAME` and `CF_ROUTE_PATTERN` are both optional by design. When
+`CF_ROUTE_PATTERN` is empty, `nuxt.config.ts` emits no `route` and flips `workers_dev`
+on, because a fork has no custom domain and would otherwise deploy something
+unreachable — do not "simplify" those back into unconditional keys, as an empty pattern
+with `custom_domain: true` is a route wrangler cannot create.
+
+The same applies to `nitro.preset`, which is spread in only when `NITRO_PRESET` is set:
+unset, Nitro auto-detects the host — `vercel` on Vercel, `cloudflare_module` under Workers
+Builds (which exports `WORKERS_CI`). Both one-click deploy buttons run the plain `build`
+script and cannot pass `NITRO_PRESET`, so pinning a fallback preset here would break them.
+
 ## Tooling
 
 - Node 24.18.1 (`.nvmrc`), pnpm 11.19.0 (`packageManager`)
@@ -100,8 +121,8 @@ full head sampling, set in `nuxt.config.ts` and baked into the generated
   `pnpm exec <bin>` inside it, and quote commands that take their own flags.
 - **The wrangler deploy config is generated into `.output/` at build time** from
   `nitro.cloudflare` in `nuxt.config.ts`. `CF_WORKER_NAME` and `CF_ROUTE_PATTERN`
-  must be set for `build:cf`, not only for `deploy:cf`. There is no checked-in
-  `wrangler.toml`.
+  must be set for `build:cf`, not only for `deploy:cf`. The checked-in
+  `wrangler.jsonc` is for the deploy button only — see Deployments above.
 - Agent skills live in `.agents/skills/` (canonical); `.claude/skills/<name>` are
   committed relative symlinks. Vendored skills are pinned in `skills-lock.json` —
   change them only via `npx skills add|update|remove`, never by hand. `orpc-api` is

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a DynDNS Service that can be used to update the IP address of a Fritz!Bo
 
 ✅ Key features:
 1️⃣ Automatic Cloudflare DNS updates 🔄
-2️⃣ Effortless deployment on Vercel with One-Click 🚀
+2️⃣ Effortless One-Click deployment on Cloudflare or Vercel 🚀
 3️⃣ Powered by Nuxt.js 🎨
 4️⃣ Open-source for community collaboration 🌍
 5️⃣ Supports both IPv4 and IPv6
@@ -45,7 +45,37 @@ The AAAA-Record will be used to update your FRITZ!Box IPv6 address in Cloudflare
 
 #### :rocket: Option 1: Self-host on Cloudflare
 
-Deploy this project to your Cloudflare account and use it as a service for your FRITZ!Box. Adjust the environment variables in the `.env` file to match your Cloudflare account and routing patterns.
+Deploy this project to your own Cloudflare account and use it as a service for your FRITZ!Box.
+
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/piscis/fritzbox-cloudflare-dyndns-vercel)
+
+Cloudflare clones this repository into your GitHub account, lets you pick a Worker name,
+then builds and deploys it. Nothing to configure: the service holds no secrets, and the
+build detects Cloudflare on its own.
+
+You end up with a Worker on `https://<worker-name>.<your-subdomain>.workers.dev`, so the
+Update URL for your FRITZ!Box is:
+
+```
+https://<worker-name>.<your-subdomain>.workers.dev/api/fritz-dyndns/?token=<pass>&record=fritz.example.com&zone=example.com&ipv4=<ipaddr>&ipv6=<ip6addr>
+```
+
+To serve it from your own domain instead, set `CF_ROUTE_PATTERN` (see
+[Environment variables](#environment-variables)) and redeploy — the workers.dev
+subdomain is switched off automatically once a custom domain is configured.
+
+> **If the build fails while installing dependencies**, Workers Builds picked its default
+> pnpm rather than the version this repo pins. Set `PNPM_VERSION` to the version in the
+> `packageManager` field of [`package.json`](./package.json) under **Worker → Settings →
+> Build → Variables** and retry. The Node version needs no help — the builder reads
+> [`.nvmrc`](./.nvmrc).
+
+<details>
+<summary>Manual deploy (advanced)</summary>
+
+Use this if you would rather deploy from your machine than through Workers Builds. Adjust
+the environment variables in the `.env` file to match your Cloudflare account and routing
+patterns.
 
 ```bash
 cp .env.example .env
@@ -63,6 +93,8 @@ pnpm exec wrangler --cwd .output deploy
 > without access to that org. The commands above are the equivalent for a fork.
 
 If necessary make some adjustments to `nuxt.config.ts` to match your Cloudflare account and routing patterns. (see the nitro preset config in the [nuxt.config.ts](./nuxt.config.ts) file)
+
+</details>
 
 #### :rocket: Option 2: Self-host on Vercel
 
@@ -92,7 +124,10 @@ https://fritzdns.piscis.dev/api/fritz-dyndns/?token=<pass>&record=fritz.example.
 | Username          | admin                                                                                                                               | You can choose whatever value you want.                                                                                                  |
 | Password          | ●●●●●●                                                                                                                              | The API token you’ve created earlier.                                                                                                    |
 
-Please note, if you use a custom Vercel deployment your service URL will be different. For example, if you're app is deployed to `https://some-random-name.vercel.app/` you have to use the following URL: `https://some-random-name.vercel.app/api/fritz-dyndns/?token=<pass>&record=fritz.example.com&zone=example.com&ipv4=<ipaddr>&ipv6=<ip6addr>` service endpoint when configuring your FRITZ!Box DynDNS settings
+Please note, if you self-host your service URL will be different — replace the host and keep
+the rest of the URL as-is. A Cloudflare deployment made with the button above answers on
+`https://<worker-name>.<your-subdomain>.workers.dev/api/fritz-dyndns/?token=...`, and a Vercel
+deployment on `https://some-random-name.vercel.app/api/fritz-dyndns/?token=...`.
 
 ### API reference
 
@@ -155,19 +190,44 @@ is never read from the environment and never stored.
 
 | Variable | Consumed by | When | Required |
 | --- | --- | --- | --- |
-| `NITRO_PRESET` | `nuxt.config.ts` → `nitro.preset` | build | Cloudflare only (Vercel auto-detects) |
-| `CF_WORKER_NAME` | `nuxt.config.ts` → `wrangler.name` | build | Cloudflare only |
-| `CF_ROUTE_PATTERN` | `nuxt.config.ts` → `wrangler.route.pattern` | build | Cloudflare only |
+| `NITRO_PRESET` | `nuxt.config.ts` → `nitro.preset` | build | manual builds only — hosts auto-detect |
+| `CF_WORKER_NAME` | `nuxt.config.ts` → `wrangler.name` | build | no — falls back to `wrangler.jsonc` |
+| `CF_ROUTE_PATTERN` | `nuxt.config.ts` → `wrangler.route.pattern` | build | no — unset ⇒ workers.dev |
 | `CF_LOG_ENABLED` | `nuxt.config.ts` → `wrangler.observability.enabled` | build | no |
-| `CLOUDFLARE_API_TOKEN` | `wrangler deploy` | deploy | Cloudflare only |
-| `CLOUDFLARE_ACCOUNT_ID` | `wrangler deploy` | deploy | Cloudflare only |
+| `WORKERS_CI` | Nitro's host auto-detection | build | set by Workers Builds itself |
+| `CLOUDFLARE_API_TOKEN` | `wrangler deploy` | deploy | manual Cloudflare deploy only |
+| `CLOUDFLARE_ACCOUNT_ID` | `wrangler deploy` | deploy | manual Cloudflare deploy only |
 
 Every `CF_*` variable is consumed at **build** time, because `nuxt.config.ts` generates
 `.output/server/wrangler.json` — so they must be set for `build:cf`, not only for
-`deploy:cf`. There is no checked-in `wrangler.toml`.
+`deploy:cf`.
+
+Leaving `CF_ROUTE_PATTERN` empty is what a one-click deploy does: no custom-domain route is
+emitted and the `workers.dev` subdomain is enabled instead, so the Worker is still reachable.
+Setting it flips both back. Likewise an empty `CF_WORKER_NAME` leaves the name to
+`wrangler.jsonc`.
+
+`NITRO_PRESET` is only needed when you build for a host by hand. Unset, `nuxt.config.ts` pins
+no preset at all and Nitro detects the host it is running on — the `vercel` preset on Vercel,
+`cloudflare_module` under Workers Builds, which exports `WORKERS_CI` for exactly that purpose.
+That is what lets both one-click buttons work without configuration.
 
 The route is configured as a Cloudflare **custom domain**, which needs only a `pattern`;
 Cloudflare infers the zone from the hostname. No `CF_ROUTE_ZONE_NAME` is required.
+
+#### Two Wrangler configs, and which one wins
+
+[`wrangler.jsonc`](./wrangler.jsonc) is checked in **only** so the Deploy to Cloudflare button
+recognises this repo as a Workers app and has a `name` to rewrite. No deploy uses it: `nuxt
+build` generates `.output/server/wrangler.json` from `nuxt.config.ts` and writes a
+`.wrangler/deploy/config.json` redirect next to it, which wrangler follows in preference to any
+root config — it prints `Using redirected Wrangler configuration` when it does. Nitro also
+merges `wrangler.jsonc` *underneath* the `nitro.cloudflare.wrangler` block, so anything set in
+both is won by `nuxt.config.ts`, and `main`/`assets` are always re-derived from the build (which
+is why each Cloudflare build logs two `is overridden and will be ignored` warnings).
+
+**Editing `wrangler.jsonc` therefore has no effect on staging or production** — change
+`nuxt.config.ts` instead.
 
 #### The two Cloudflare tokens are not interchangeable
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -20,7 +20,16 @@ const workerName = env('CF_WORKER_NAME')
 const routePattern = env('CF_ROUTE_PATTERN')
 
 export default defineNuxtConfig({
-  compatibilityDate: '2025-06-06',
+  // Scoped to Cloudflare on purpose. The bare-string form sets compatx's
+  // `default`, which also gates the Vercel preset (it starts emitting
+  // observability routes at >= 2025-07-15) and the `cloudflare-dev` preset that
+  // `nuxt dev` would silently switch to — neither is part of this bump. Keep
+  // `default` explicit: compatx back-fills an omitted one with the *highest*
+  // platform date, which would reintroduce the global bump.
+  //
+  // Only the `cloudflare` key becomes wrangler's `compatibility_date`, and
+  // wrangler.jsonc outranks it in Nitro's merge — keep the two in step.
+  compatibilityDate: { default: '2025-06-06', cloudflare: '2026-08-02' },
   devtools: { enabled: true },
   modules: [
     '@nuxt/icon',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -11,6 +11,14 @@ function env(name: string, fallback = '') {
   return (import.meta.env[name] ?? fallback).trim()
 }
 
+/**
+ * Both are empty for a fork deployed through the Deploy to Cloudflare button,
+ * and every Worker setting below that would otherwise be built from an empty
+ * string keys off that. See `nitro.cloudflare.wrangler`.
+ */
+const workerName = env('CF_WORKER_NAME')
+const routePattern = env('CF_ROUTE_PATTERN')
+
 export default defineNuxtConfig({
   compatibilityDate: '2025-06-06',
   devtools: { enabled: true },
@@ -62,7 +70,7 @@ export default defineNuxtConfig({
       // Deliberately under `public` — `server/routes/api/[...].ts` destructures
       // top-level `appName`/`appVersion`, and defining those would silently
       // rewrite /api/spec.json and the e2e assertion that pins its title.
-      siteHost: env('CF_ROUTE_PATTERN'),
+      siteHost: routePattern,
     },
   },
   app: {
@@ -112,8 +120,10 @@ export default defineNuxtConfig({
       wasm: true,
     },
     // Only pin a preset when NITRO_PRESET is set (e.g. cloudflare_module for
-    // build:cf). Leaving it unset lets Nitro auto-detect — on Vercel that is
-    // the vercel preset, which the Deploy Button one-click flow needs.
+    // build:cf). Leaving it unset lets Nitro auto-detect the host — the vercel
+    // preset on Vercel, cloudflare_module under Workers Builds (which exports
+    // WORKERS_CI). Both one-click deploy buttons run the plain `build` script
+    // and have nowhere to pass NITRO_PRESET, so they depend on that detection.
     ...(env('NITRO_PRESET')
       ? { preset: env('NITRO_PRESET') }
       : {}),
@@ -121,9 +131,16 @@ export default defineNuxtConfig({
       deployConfig: true,
       nodeCompat: true,
       wrangler: {
-        name: env('CF_WORKER_NAME'),
+        // Nitro merges this object *over* the root wrangler.jsonc, and defu
+        // treats '' as a value rather than an absence — so setting an empty
+        // name here would mask the one the deploy button writes into that file.
+        ...(workerName ? { name: workerName } : {}),
         preview_urls: false,
-        workers_dev: false,
+        // Our own deployments are reached through the custom domain below, so
+        // the workers.dev subdomain stays off. A fork has no domain to attach:
+        // there it is the only way in, and disabling it deploys something
+        // unreachable.
+        workers_dev: !routePattern,
         upload_source_maps: true,
         observability: {
           enabled: env('CF_LOG_ENABLED') === 'true',
@@ -135,10 +152,12 @@ export default defineNuxtConfig({
         // A custom-domain route needs only `pattern`; Cloudflare infers the zone
         // from the hostname. wrangler's own schema requires zone_name/zone_id
         // solely for non-custom-domain routes.
-        route: {
-          pattern: env('CF_ROUTE_PATTERN'),
-          custom_domain: true,
-        },
+        //
+        // Emitted only when there is a pattern to attach — `custom_domain: true`
+        // against an empty pattern is a route wrangler cannot create.
+        ...(routePattern
+          ? { route: { pattern: routePattern, custom_domain: true } }
+          : {}),
       },
     },
     routeRules: {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,32 @@
+{
+  // This file exists for the "Deploy to Cloudflare" button in the README, which
+  // requires a checked-in Wrangler config to recognise the repository as a
+  // Workers application. It rewrites `name` to whatever Worker the person
+  // clicking it chooses, then hands the repo to Workers Builds.
+  //
+  // It is NOT the config any deploy actually uses. `nuxt build` regenerates
+  // .output/server/wrangler.json from nuxt.config.ts and writes
+  // .wrangler/deploy/config.json alongside it; wrangler follows that redirect,
+  // which outranks this file for `deploy`, `dev` and `versions upload`. Nitro
+  // also merges the values below *under* nuxt.config.ts's `nitro.cloudflare.
+  // wrangler` block, so anything set in both is won by nuxt.config.ts.
+  //
+  // Changing this file therefore has no effect on staging or production.
+  //
+  // Deliberately no "$schema": every key here is copied into the generated
+  // config, where a relative node_modules path would no longer resolve.
+  "name": "fritzbox-cloudflare-dyndns",
+  // Nitro always re-derives `main` and `assets` from the build output and logs
+  // that it is overriding them. Both are kept anyway: Cloudflare documents
+  // name/main/compatibility_date as the minimum a Wrangler config needs, and
+  // the button reads this file before any build has produced the real one.
+  "main": "./.output/server/index.mjs",
+  // Keep in step with `compatibilityDate` in nuxt.config.ts. In the merge this
+  // value outranks the date Nitro would otherwise default to.
+  "compatibility_date": "2025-06-06",
+  "compatibility_flags": ["nodejs_compat"],
+  "assets": {
+    "binding": "ASSETS",
+    "directory": "./.output/public"
+  }
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -21,9 +21,14 @@
   // name/main/compatibility_date as the minimum a Wrangler config needs, and
   // the button reads this file before any build has produced the real one.
   "main": "./.output/server/index.mjs",
-  // Keep in step with `compatibilityDate` in nuxt.config.ts. In the merge this
-  // value outranks the date Nitro would otherwise default to.
-  "compatibility_date": "2025-06-06",
+  // Keep in step with `compatibilityDate.cloudflare` in nuxt.config.ts. In the
+  // merge this value outranks the date Nitro derives, so it is what lands in
+  // .output/server/wrangler.json and what actually deploys.
+  //
+  // workerd refuses a date in the future, so this cannot be raised past the day
+  // it is bumped — and this workerd build refuses anything after 2026-08-06, so
+  // going further needs a wrangler upgrade first.
+  "compatibility_date": "2026-08-02",
   "compatibility_flags": ["nodejs_compat"],
   "assets": {
     "binding": "ASSETS",


### PR DESCRIPTION
## What

Adds a **Deploy to Cloudflare** button to the README, alongside the existing Deploy to Vercel one — and makes it actually work.

[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/piscis/fritzbox-cloudflare-dyndns-vercel)

## Why the markdown alone wasn't enough

Cloudflare's button requires a **checked-in Wrangler config** — this repo has none, because `nuxt.config.ts` generates `.output/server/wrangler.json` at build time. On top of that, two settings broke a forked deploy:

1. `preset: env('NITRO_PRESET', 'node-server')` — the button's autodetected build command is the plain `build` script, with nowhere to pass `NITRO_PRESET`, so a fork built a **node server** rather than a Worker.
2. With no `CF_*` variables set, `defu` treats `''` as a value, so the fork got `route: { pattern: '', custom_domain: true }` together with `workers_dev: false` — a Worker that deploys and is then **unreachable**.

(2) was a latent bug for any Cloudflare build without the `CF_*` variables, not just for the button.

## Changes

| File | Change |
|---|---|
| `wrangler.jsonc` *(new)* | Button-only defaults: `name`, `main`, `compatibility_date`, `nodejs_compat`, `assets`. |
| `nuxt.config.ts` | Preset self-selects on `WORKERS_CI`; `name`/`route` emitted only when set; `workers_dev: !routePattern`. |
| `README.md` | Button leads Option 1, manual CLI moves into `<details>`; env table updated; corrects the now-false "There is no checked-in `wrangler.toml`". |
| `.env.example`, `AGENTS.md` | Document the two-config split and the optional `CF_*` variables. |

### The two configs don't fight

`nuxt build` writes `.wrangler/deploy/config.json` pointing at the generated config, and wrangler follows that redirect over any root file. Confirmed in the dry run:

```
Using redirected Wrangler configuration.
 - Configuration being used: ".output/server/wrangler.json"
 - Original user's configuration: "wrangler.jsonc"
```

Nitro also merges `wrangler.jsonc` *underneath* `nitro.cloudflare.wrangler`, so `nuxt.config.ts` still wins every contested key. `main`/`assets` are always re-derived, which is why Cloudflare builds now log two `is overridden and will be ignored` warnings — expected, documented in both `AGENTS.md` and the README.

## Verification

| Check | Result |
|---|---|
| Fork build (`WORKERS_CI=1`, no `CF_*`) | preset `cloudflare-module`, name from `wrangler.jsonc`, `workers_dev: true`, **no `route`** |
| `wrangler deploy --dry-run` | passes, `ASSETS` binding present, follows the redirect |
| Production path (`CF_*` set) | **identical to before** — custom-domain route, `workers_dev: false`, observability on |
| Default `pnpm build` (no env) | unchanged — `node-server`, no wrangler.json generated |
| `lint` / `typecheck` / `test` | clean / clean / **115 passed (14 files)** |

The button itself can only be exercised end-to-end once this is on the public default branch, since Cloudflare clones from there.

## Note for whoever deploys a fork

Workers Builds defaults to pnpm 10.x while this repo pins pnpm 11 via `packageManager`. If the install step fails, set `PNPM_VERSION` under **Worker → Settings → Build → Variables**. Node needs no help — the builder reads `.nvmrc`. This is called out in the README.
