### PR TITLE
fix(modem): build the dial-up audio graph only after a user gesture

### DIFF
--- a/app/composables/useModemDialup.ts
+++ b/app/composables/useModemDialup.ts
@@ -3,13 +3,14 @@
  *
  * Module-scoped on purpose — the landing page mounts a single toggle and a
  * single spectrum, and MediaElementSource can only be created once per element.
- * Lazy: AudioContext + analyser appear on the first successful play so
- * prerender / SSR never touch Web Audio. The clip stays `preload="none"` until
- * that first play (autoplay attempt or a click).
+ * Lazy: AudioContext + analyser appear on the first gesture so prerender / SSR
+ * never touch Web Audio. The clip stays `preload="none"` until the first play
+ * (autoplay attempt or a click).
  *
  * Unmuted autoplay is still gated by the browser: we schedule a try two seconds
  * after mount, and if the UA refuses, the button stays honest and the click
- * path remains the reliable fallback.
+ * path remains the reliable fallback. That try must not build the graph —
+ * see `ensureGraph`.
  */
 
 const SOUND = '/sounds/modem-dial-up.mp3'
@@ -23,9 +24,50 @@ let analyser: AnalyserNode | null = null
 let sourceBound = false
 let autoplayTimer: ReturnType<typeof setTimeout> | null = null
 let autoplayCancelled = false
+let gestureSeen = false
+let gestureBound = false
 
+// Anything Chrome counts as activation for the autoplay policy. `keydown`
+// keeps the graph reachable for visitors who never point at anything.
+const GESTURE_EVENTS = ['pointerdown', 'keydown', 'touchstart'] as const
+
+function onFirstGesture(): void {
+  unbindGesture()
+  gestureSeen = true
+
+  // Only if the clip is already running: the autoplay try got through without a
+  // graph, so this is the first moment we can give the spectrum real bins.
+  // Otherwise the click path builds it and idle visitors pay for nothing.
+  if (playing.value)
+    ensureGraph()
+}
+
+function bindGesture(): void {
+  if (!import.meta.client || gestureBound || gestureSeen)
+    return
+
+  for (const type of GESTURE_EVENTS)
+    window.addEventListener(type, onFirstGesture, { once: true, passive: true })
+  gestureBound = true
+}
+
+function unbindGesture(): void {
+  if (!gestureBound)
+    return
+
+  for (const type of GESTURE_EVENTS)
+    window.removeEventListener(type, onFirstGesture)
+  gestureBound = false
+}
+
+/**
+ * Never call this before a gesture. An AudioContext constructed without one
+ * starts `suspended` (and Chrome logs the autoplay warning), while
+ * `createMediaElementSource` has already rerouted the element's output into
+ * that frozen graph — the clip would play silently behind a pressed button.
+ */
 function ensureGraph(): AnalyserNode | null {
-  if (!import.meta.client || !audioEl || sourceBound)
+  if (!import.meta.client || !audioEl || sourceBound || !gestureSeen)
     return analyser
 
   try {
@@ -64,14 +106,29 @@ function stop(): void {
   playing.value = false
 }
 
-async function play(): Promise<void> {
+/**
+ * `viaGesture` marks a call that runs inside a user activation (the toggle
+ * click). Only those may touch Web Audio; the scheduled autoplay try goes
+ * straight to the element and waits for a gesture to pick up the graph.
+ */
+async function play(viaGesture = false): Promise<void> {
   if (playing.value || !audioEl)
     return
 
+  if (viaGesture) {
+    unbindGesture()
+    gestureSeen = true
+  }
+
   try {
-    ensureGraph()
-    if (ctx?.state === 'suspended')
-      await ctx.resume()
+    if (gestureSeen) {
+      ensureGraph()
+      if (ctx?.state === 'suspended')
+        await ctx.resume()
+    }
+    else {
+      bindGesture()
+    }
 
     await audioEl.play()
     playing.value = true
@@ -111,15 +168,20 @@ async function toggle(): Promise<void> {
     return
   }
 
-  await play()
+  await play(true)
 }
 
 function tearDownGraph(): void {
+  unbindGesture()
   if (typeof ctx?.close === 'function')
     void ctx.close()
   ctx = null
   analyser = null
   sourceBound = false
+  // Activation is tracked per graph lifetime, not per document: a remount costs
+  // at most one gesture before the spectrum comes back, and the invariant
+  // "no graph without a gesture we observed ourselves" stays checkable.
+  gestureSeen = false
 }
 
 export function useModemDialup() {

--- a/tests/nuxt/index-page.nuxt.test.ts
+++ b/tests/nuxt/index-page.nuxt.test.ts
@@ -21,6 +21,9 @@ registerEndpoint('/api/health-check', defineEventHandler((event) => {
   return health.body
 }))
 
+/** Counts constructions so tests can assert Web Audio stayed untouched. */
+let audioContextConstructed = 0
+
 function stubAudioContext(): void {
   // happy-dom has no Web Audio; the composable must still play through <audio>.
   class FakeAnalyser {
@@ -37,6 +40,10 @@ function stubAudioContext(): void {
 
   class FakeAudioContext {
     state = 'running'
+    constructor() {
+      audioContextConstructed++
+    }
+
     resume = vi.fn(() => Promise.resolve())
     close = vi.fn(() => Promise.resolve())
     createAnalyser = vi.fn(() => new FakeAnalyser())
@@ -55,6 +62,7 @@ describe('index page', () => {
     // happy-dom implements no media playback.
     HTMLMediaElement.prototype.play = vi.fn(() => Promise.resolve())
     HTMLMediaElement.prototype.pause = vi.fn()
+    audioContextConstructed = 0
     stubAudioContext()
   })
 
@@ -94,6 +102,35 @@ describe('index page', () => {
 
       expect(HTMLMediaElement.prototype.play).toHaveBeenCalledOnce()
       expect(page.find('button[aria-pressed]').attributes('aria-pressed')).toBe('true')
+    })
+
+    it('builds no audio graph for the autoplay try, only on a gesture', async () => {
+      const page = await mountSuspended(IndexPage)
+
+      await vi.advanceTimersByTimeAsync(2000)
+      await flushPromises()
+
+      // A context built here would start suspended (Chrome logs the autoplay
+      // warning) and swallow the element's output — a pressed button over
+      // silence. See useModemDialup's ensureGraph.
+      expect(HTMLMediaElement.prototype.play).toHaveBeenCalledOnce()
+      expect(audioContextConstructed).toBe(0)
+
+      // The gesture the composable has been waiting for lights the spectrum up.
+      window.dispatchEvent(new Event('pointerdown'))
+      await flushPromises()
+
+      expect(audioContextConstructed).toBe(1)
+      expect(page.find('button[aria-pressed]').attributes('aria-pressed')).toBe('true')
+    })
+
+    it('builds the graph on a click, which is already a gesture', async () => {
+      const page = await mountSuspended(IndexPage)
+
+      await page.find('button[aria-pressed]').trigger('click')
+      await flushPromises()
+
+      expect(audioContextConstructed).toBe(1)
     })
 
     it('does not autoplay after the visitor has already used the button', async () => {


### PR DESCRIPTION
## The error

Every production page load logged, with no interaction:

```
The AudioContext was not allowed to start. It must be resumed (or created) after a user gesture on the page.
```

`useModemDialup` schedules an unmuted autoplay try two seconds after mount. That try called `ensureGraph()`, so Chrome constructed the `AudioContext` with no user activation — it starts `suspended` and logs the warning.

## The defect underneath

The warning was the visible symptom, not the whole problem. `createMediaElementSource()` permanently reroutes the `<audio>` element's output into the graph. On browsers that *do* allow the unmuted autoplay — Chrome does at a high media engagement score — the clip played into a frozen context: silence behind `aria-pressed="true"`, and a spectrum reading zeroed bins.

That is precisely the lying button the composable's own comments set out to avoid.

## The fix

Web Audio is now gated on an activation the composable observed itself:

- `play()` takes `viaGesture`. `toggle()` (the click) passes `true`; the autoplay timer does not. Only a gesture call may construct the context.
- The no-gesture path goes straight to `audioEl.play()` and registers a one-shot `pointerdown`/`keydown`/`touchstart` listener. If autoplay got through, the visitor's first interaction anywhere attaches the graph — connecting a `MediaElementSource` mid-playback is fine — and the spectrum lights up.
- `ensureGraph()` carries `!gestureSeen` as a hard guard, documented with the reason.
- Until the graph exists, `getAnalyser()` returns `null` and `ModemSpectrum` draws its dormant baseline, a path it already handled.

`gestureSeen` resets in `tearDownGraph()`, so activation is tracked per graph lifetime rather than per document. A remount costs at most one gesture before the spectrum returns, and it keeps the invariant testable.

## Tests

Two added, backed by a construction counter on the existing `FakeAudioContext` stub:

- the autoplay try must construct zero contexts, and a subsequent `pointerdown` must construct exactly one
- a click constructs one directly, since it is already a gesture

I confirmed the first test fails against the pre-fix code (`expected 1 to be +0`), so it genuinely pins the regression rather than passing vacuously.

Full suite green: 117 tests across 14 files, plus `pnpm lint` and `pnpm typecheck`.