### PR TITLE
feat(ui): pulse the idle dial-up button with a soft yellow glow

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -366,6 +366,30 @@ body {
 }
 
 /* ============================================================
+   DIAL-UP IDLE — soft yellow pulse so the easter egg reads as pressable.
+   Dropped while connecting (class unbound when playing).
+   ============================================================ */
+.dialup-idle {
+  animation: dialup-idle-glow 2.4s ease-in-out infinite;
+}
+
+.dialup-idle:hover,
+.dialup-idle:focus-visible {
+  animation-play-state: paused;
+}
+
+@keyframes dialup-idle-glow {
+  0%, 100% {
+    box-shadow: 0 0 0 transparent;
+    border-color: var(--crt-line);
+  }
+  50% {
+    box-shadow: 0 0 18px rgb(255 228 0 / 0.22);
+    border-color: color-mix(in srgb, var(--fritz-yellow) 35%, var(--crt-line));
+  }
+}
+
+/* ============================================================
    MOTION — every animation above degrades to its END state, never to a
    faster version of itself.
    ============================================================ */
@@ -373,6 +397,7 @@ body {
   .flicker,
   .cursor,
   .lamp--pulse,
+  .dialup-idle,
   [data-boot="run"] .log-line > span:last-child {
     animation: none;
   }
@@ -382,4 +407,9 @@ body {
   [data-boot="run"] .log-line > span:last-child { clip-path: none; }
 
   .wave-bar { animation: none; height: 60%; }
+
+  .dialup-idle {
+    box-shadow: 0 0 14px rgb(255 228 0 / 0.16);
+    border-color: color-mix(in srgb, var(--fritz-yellow) 28%, var(--crt-line));
+  }
 }

--- a/app/components/ModemToggle.vue
+++ b/app/components/ModemToggle.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
 /**
- * The dial-up easter egg: autoplay after a short beat, click to stop/restart.
+ * The dial-up easter egg: click to play, click again to stop/restart.
  *
- * Unmuted autoplay is blocked by Chrome and Safari for most visitors, so the
- * scheduled try may no-op — the button stays the reliable path and never lies
- * about a pressed state. Markup stays SSR-safe (`<audio preload="none">`),
- * and the Web Audio graph lives in `useModemDialup` for the spectrum.
+ * Markup stays SSR-safe (`<audio preload="none">`), and the Web Audio graph
+ * lives in `useModemDialup` for the spectrum — built only on a click so the
+ * button never claims to be playing over silence.
  */
 const {
   sound,
@@ -13,21 +12,16 @@ const {
   bindAudio,
   toggle,
   stop,
-  scheduleAutoplay,
-  cancelAutoplay,
 } = useModemDialup()
 
 const audio = useTemplateRef<HTMLAudioElement>('audio')
 
 watch(audio, (el) => {
-  if (el) {
+  if (el)
     bindAudio(el)
-    scheduleAutoplay()
-  }
 }, { immediate: true })
 
 onBeforeUnmount(() => {
-  cancelAutoplay()
   stop()
   bindAudio(null)
 })

--- a/app/components/ModemToggle.vue
+++ b/app/components/ModemToggle.vue
@@ -36,6 +36,7 @@ onBeforeUnmount(() => {
 <template>
   <BracketButton
     type="button"
+    :class="{ 'dialup-idle': !playing }"
     :aria-pressed="playing"
     :aria-label="playing ? 'Stop the modem handshake' : 'Play the modem handshake'"
     @click="toggle"

--- a/app/composables/useModemDialup.ts
+++ b/app/composables/useModemDialup.ts
@@ -3,18 +3,11 @@
  *
  * Module-scoped on purpose — the landing page mounts a single toggle and a
  * single spectrum, and MediaElementSource can only be created once per element.
- * Lazy: AudioContext + analyser appear on the first gesture so prerender / SSR
- * never touch Web Audio. The clip stays `preload="none"` until the first play
- * (autoplay attempt or a click).
- *
- * Unmuted autoplay is still gated by the browser: we schedule a try two seconds
- * after mount, and if the UA refuses, the button stays honest and the click
- * path remains the reliable fallback. That try must not build the graph —
- * see `ensureGraph`.
+ * Lazy: AudioContext + analyser appear on the first click so prerender / SSR
+ * never touch Web Audio. The clip stays `preload="none"` until that click.
  */
 
 const SOUND = '/sounds/modem-dial-up.mp3'
-const AUTOPLAY_DELAY_MS = 2000
 
 const playing = ref(false)
 
@@ -22,52 +15,15 @@ let audioEl: HTMLAudioElement | null = null
 let ctx: AudioContext | null = null
 let analyser: AnalyserNode | null = null
 let sourceBound = false
-let autoplayTimer: ReturnType<typeof setTimeout> | null = null
-let autoplayCancelled = false
-let gestureSeen = false
-let gestureBound = false
-
-// Anything Chrome counts as activation for the autoplay policy. `keydown`
-// keeps the graph reachable for visitors who never point at anything.
-const GESTURE_EVENTS = ['pointerdown', 'keydown', 'touchstart'] as const
-
-function onFirstGesture(): void {
-  unbindGesture()
-  gestureSeen = true
-
-  // Only if the clip is already running: the autoplay try got through without a
-  // graph, so this is the first moment we can give the spectrum real bins.
-  // Otherwise the click path builds it and idle visitors pay for nothing.
-  if (playing.value)
-    ensureGraph()
-}
-
-function bindGesture(): void {
-  if (!import.meta.client || gestureBound || gestureSeen)
-    return
-
-  for (const type of GESTURE_EVENTS)
-    window.addEventListener(type, onFirstGesture, { once: true, passive: true })
-  gestureBound = true
-}
-
-function unbindGesture(): void {
-  if (!gestureBound)
-    return
-
-  for (const type of GESTURE_EVENTS)
-    window.removeEventListener(type, onFirstGesture)
-  gestureBound = false
-}
 
 /**
- * Never call this before a gesture. An AudioContext constructed without one
- * starts `suspended` (and Chrome logs the autoplay warning), while
+ * Only called from the toggle click. An AudioContext constructed without a
+ * user activation starts `suspended` (and Chrome logs a warning), while
  * `createMediaElementSource` has already rerouted the element's output into
  * that frozen graph — the clip would play silently behind a pressed button.
  */
 function ensureGraph(): AnalyserNode | null {
-  if (!import.meta.client || !audioEl || sourceBound || !gestureSeen)
+  if (!import.meta.client || !audioEl || sourceBound)
     return analyser
 
   try {
@@ -106,29 +62,14 @@ function stop(): void {
   playing.value = false
 }
 
-/**
- * `viaGesture` marks a call that runs inside a user activation (the toggle
- * click). Only those may touch Web Audio; the scheduled autoplay try goes
- * straight to the element and waits for a gesture to pick up the graph.
- */
-async function play(viaGesture = false): Promise<void> {
+async function play(): Promise<void> {
   if (playing.value || !audioEl)
     return
 
-  if (viaGesture) {
-    unbindGesture()
-    gestureSeen = true
-  }
-
   try {
-    if (gestureSeen) {
-      ensureGraph()
-      if (ctx?.state === 'suspended')
-        await ctx.resume()
-    }
-    else {
-      bindGesture()
-    }
+    ensureGraph()
+    if (ctx?.state === 'suspended')
+      await ctx.resume()
 
     await audioEl.play()
     playing.value = true
@@ -139,49 +80,21 @@ async function play(viaGesture = false): Promise<void> {
   }
 }
 
-function cancelAutoplay(): void {
-  autoplayCancelled = true
-  if (autoplayTimer !== null) {
-    clearTimeout(autoplayTimer)
-    autoplayTimer = null
-  }
-}
-
-function scheduleAutoplay(delayMs = AUTOPLAY_DELAY_MS): void {
-  if (autoplayTimer !== null)
-    clearTimeout(autoplayTimer)
-
-  autoplayCancelled = false
-  autoplayTimer = setTimeout(() => {
-    autoplayTimer = null
-    if (!autoplayCancelled && !playing.value)
-      void play()
-  }, delayMs)
-}
-
 async function toggle(): Promise<void> {
-  // Any click means the visitor took over — do not restart after they stop.
-  cancelAutoplay()
-
   if (playing.value) {
     stop()
     return
   }
 
-  await play(true)
+  await play()
 }
 
 function tearDownGraph(): void {
-  unbindGesture()
   if (typeof ctx?.close === 'function')
     void ctx.close()
   ctx = null
   analyser = null
   sourceBound = false
-  // Activation is tracked per graph lifetime, not per document: a remount costs
-  // at most one gesture before the spectrum comes back, and the invariant
-  // "no graph without a gesture we observed ourselves" stays checkable.
-  gestureSeen = false
 }
 
 export function useModemDialup() {
@@ -192,7 +105,6 @@ export function useModemDialup() {
     // MediaElementSource is permanently tied to one element. Remounts (tests,
     // client navigations) get a fresh graph.
     if (audioEl) {
-      cancelAutoplay()
       stop()
       tearDownGraph()
     }
@@ -206,8 +118,6 @@ export function useModemDialup() {
     play,
     toggle,
     stop,
-    scheduleAutoplay,
-    cancelAutoplay,
     getAnalyser: (): AnalyserNode | null => analyser,
   }
 }

--- a/tests/nuxt/index-page.nuxt.test.ts
+++ b/tests/nuxt/index-page.nuxt.test.ts
@@ -2,7 +2,7 @@ import { mountSuspended, registerEndpoint } from '@nuxt/test-utils/runtime'
 import { flushPromises } from '@vue/test-utils'
 // Nitro's auto-imports do not reach test files, so h3 is imported directly.
 import { defineEventHandler, setResponseStatus } from 'h3'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import IndexPage from '~/pages/index.vue'
 
 /**
@@ -67,21 +67,13 @@ describe('index page', () => {
   })
 
   describe('the modem easter egg', () => {
-    beforeEach(() => {
-      vi.useFakeTimers()
-    })
-
-    afterEach(() => {
-      vi.useRealTimers()
-    })
-
     it('wires up the clip without an autoplay attribute or immediate play', async () => {
       const page = await mountSuspended(IndexPage)
       const audio = page.find('audio')
 
       expect(audio.exists()).toBe(true)
       expect(audio.attributes('src')).toBe('/sounds/modem-dial-up.mp3')
-      // 852 KB stays unfetched until the first play() — autoplay try or a click.
+      // 852 KB stays unfetched until the visitor clicks dial up.
       expect(audio.attributes('preload')).toBe('none')
       // No HTML autoplay attribute: that path is blocked unmuted and used to
       // render as an inert grey player mid-layout.
@@ -90,65 +82,15 @@ describe('index page', () => {
       expect(HTMLMediaElement.prototype.play).not.toHaveBeenCalled()
     })
 
-    it('autoplays two seconds after mount when the browser allows it', async () => {
+    it('builds the audio graph on click', async () => {
       const page = await mountSuspended(IndexPage)
 
-      await vi.advanceTimersByTimeAsync(1999)
-      await flushPromises()
-      expect(HTMLMediaElement.prototype.play).not.toHaveBeenCalled()
-
-      await vi.advanceTimersByTimeAsync(1)
-      await flushPromises()
-
-      expect(HTMLMediaElement.prototype.play).toHaveBeenCalledOnce()
-      expect(page.find('button[aria-pressed]').attributes('aria-pressed')).toBe('true')
-    })
-
-    it('builds no audio graph for the autoplay try, only on a gesture', async () => {
-      const page = await mountSuspended(IndexPage)
-
-      await vi.advanceTimersByTimeAsync(2000)
-      await flushPromises()
-
-      // A context built here would start suspended (Chrome logs the autoplay
-      // warning) and swallow the element's output — a pressed button over
-      // silence. See useModemDialup's ensureGraph.
-      expect(HTMLMediaElement.prototype.play).toHaveBeenCalledOnce()
       expect(audioContextConstructed).toBe(0)
-
-      // The gesture the composable has been waiting for lights the spectrum up.
-      window.dispatchEvent(new Event('pointerdown'))
-      await flushPromises()
-
-      expect(audioContextConstructed).toBe(1)
-      expect(page.find('button[aria-pressed]').attributes('aria-pressed')).toBe('true')
-    })
-
-    it('builds the graph on a click, which is already a gesture', async () => {
-      const page = await mountSuspended(IndexPage)
 
       await page.find('button[aria-pressed]').trigger('click')
       await flushPromises()
 
       expect(audioContextConstructed).toBe(1)
-    })
-
-    it('does not autoplay after the visitor has already used the button', async () => {
-      const page = await mountSuspended(IndexPage)
-      const toggle = page.find('button[aria-pressed]')
-
-      await toggle.trigger('click')
-      await flushPromises()
-      expect(HTMLMediaElement.prototype.play).toHaveBeenCalledOnce()
-
-      // Stop, then let the scheduled delay elapse — must not restart on its own.
-      await toggle.trigger('click')
-      await flushPromises()
-      await vi.advanceTimersByTimeAsync(2000)
-      await flushPromises()
-
-      expect(HTMLMediaElement.prototype.play).toHaveBeenCalledOnce()
-      expect(toggle.attributes('aria-pressed')).toBe('false')
     })
 
     it('mounts a decorative spectrum canvas behind the copy', async () => {
@@ -170,6 +112,21 @@ describe('index page', () => {
 
       expect(HTMLMediaElement.prototype.play).toHaveBeenCalledOnce()
       expect(toggle.attributes('aria-pressed')).toBe('true')
+    })
+
+    it('stops on a second click', async () => {
+      const page = await mountSuspended(IndexPage)
+      const toggle = page.find('button[aria-pressed]')
+
+      await toggle.trigger('click')
+      await flushPromises()
+      expect(toggle.attributes('aria-pressed')).toBe('true')
+
+      await toggle.trigger('click')
+      await flushPromises()
+
+      expect(toggle.attributes('aria-pressed')).toBe('false')
+      expect(HTMLMediaElement.prototype.pause).toHaveBeenCalled()
     })
 
     it('stays unpressed when the browser refuses to play', async () => {


### PR DESCRIPTION
## Summary
- Soft FRITZ-yellow pulse on the dial-up button whenever it is idle (`!playing`), so the easter egg reads as pressable
- Pulse pauses on hover/focus and is removed while connecting; `prefers-reduced-motion` keeps a static soft glow instead
- Remove scheduled autoplay — the handshake only starts when the visitor clicks dial up (Web Audio graph builds on that click)

## Test plan
- [ ] Load the landing page — idle **dial up** button gently pulses yellow; audio does **not** start on its own
- [ ] Click it — pulse stops, **connecting…** + wave bars + sound
- [ ] Stop playback — pulse returns; nothing restarts until another click
- [ ] Hover idle button — pulse pauses; green hover shadow still applies
- [ ] With reduced motion enabled — static soft yellow glow, no animation